### PR TITLE
fixes unit tests after upgrade to react-redux v7

### DIFF
--- a/client/src/containers/App/test/app.spec.jsx
+++ b/client/src/containers/App/test/app.spec.jsx
@@ -27,11 +27,11 @@ describe('<App />', () => {
     expect(received).toEqual(expected);
   });
   test('should render a <Header /> component as child', () => {
-    const headerLength = getWrapper(store).dive().find(Header).length;
+    const headerLength = getWrapper(store).dive().dive().find(Header).length;
     expect(headerLength).toEqual(1);
   });
   test('if user exists render LoggedInView as child but not LoggedOutView', () => {
-    const deepWrapper = getWrapper(store).dive();
+    const deepWrapper = getWrapper(store).dive().dive();
     const loggedInViewLength = deepWrapper.find(LoggedInView).length;
     const loggedOutViewLength = deepWrapper.find(LoggedOutView).length;
     const loadingDivLength = deepWrapper.find('.loading').length;
@@ -41,7 +41,7 @@ describe('<App />', () => {
   });
   test('if user does not exist and no token render LoggedOutView as child', () => {
     const modifiedStore = { user: { currentUser: null } };
-    const deepWrapper = getWrapper(modifiedStore).dive();
+    const deepWrapper = getWrapper(modifiedStore).dive().dive();
     deepWrapper.setState({ isTokenMissing: true });
     const loggedInViewLength = deepWrapper.find(LoggedInView).length;
     const loggedOutViewLength = deepWrapper.find(LoggedOutView).length;
@@ -52,7 +52,7 @@ describe('<App />', () => {
   });
   test('if user does not exist and token exists render LoggedOutView as child', () => {
     const modifiedStore = { user: { currentUser: null } };
-    const deepWrapper = getWrapper(modifiedStore).dive();
+    const deepWrapper = getWrapper(modifiedStore).dive().dive();
     deepWrapper.setState({ isTokenMissing: false });
     const loggedInViewLength = deepWrapper.find(LoggedInView).length;
     const loggedOutViewLength = deepWrapper.find(LoggedOutView).length;
@@ -62,7 +62,7 @@ describe('<App />', () => {
     expect(loadingDivLength).toEqual(1);
   });
   test('should map currentUser from state to props', () => {
-    const received = getWrapper(store).prop('currentUser');
+    const received = getWrapper(store).prop('children').props.currentUser;
     const expected = store.user.currentUser;
     expect(received).toEqual(expected);
   });

--- a/client/src/containers/CreateDraft/test/createDraft.spec.jsx
+++ b/client/src/containers/CreateDraft/test/createDraft.spec.jsx
@@ -48,13 +48,13 @@ describe('<CreateDraft />', () => {
       expect(received).toEqual(expected);
     });
     test('should render a <Form /> component as child if form not submitted yet', () => {
-      const deepWrapper = wrapper.dive();
+      const deepWrapper = wrapper.dive().dive();
       deepWrapper.setState({ isSubmitComplete: false });
       const formLength = deepWrapper.find(Form).length;
       expect(formLength).toEqual(1);
     });
     test('should not render <Form /> component as child if form submitted', () => {
-      const deepWrapper = wrapper.dive();
+      const deepWrapper = wrapper.dive().dive();
       deepWrapper.setState({ isSubmitComplete: true });
       const formLength = deepWrapper.find(Form).length;
       expect(formLength).toEqual(0);

--- a/client/src/containers/CreatePlayer/test/createPlayer.spec.jsx
+++ b/client/src/containers/CreatePlayer/test/createPlayer.spec.jsx
@@ -50,13 +50,13 @@ describe('<CreatePlayer />', () => {
       expect(received).toEqual(expected);
     });
     test('should render a <Form /> component as child if form not submitted yet', () => {
-      const deepWrapper = wrapper.dive();
+      const deepWrapper = wrapper.dive().dive();
       deepWrapper.setState({ isSubmitComplete: false });
       const formLength = deepWrapper.find(Form).length;
       expect(formLength).toEqual(1);
     });
     test('should not render <Form /> component as child if form submitted', () => {
-      const deepWrapper = wrapper.dive();
+      const deepWrapper = wrapper.dive().dive();
       deepWrapper.setState({ isSubmitComplete: true });
       const formLength = deepWrapper.find(Form).length;
       expect(formLength).toEqual(0);

--- a/client/src/containers/CreateTeam/test/createTeam.spec.jsx
+++ b/client/src/containers/CreateTeam/test/createTeam.spec.jsx
@@ -42,13 +42,13 @@ describe('<CreateTeam />', () => {
       expect(received).toEqual(expected);
     });
     test('should render a <Form /> component as child if form not submitted yet', () => {
-      const deepWrapper = wrapper.dive();
+      const deepWrapper = wrapper.dive().dive();
       deepWrapper.setState({ isSubmitComplete: false });
       const formLength = deepWrapper.find(Form).length;
       expect(formLength).toEqual(1);
     });
     test('should not render <Form /> component as child if form submitted', () => {
-      const deepWrapper = wrapper.dive();
+      const deepWrapper = wrapper.dive().dive();
       deepWrapper.setState({ isSubmitComplete: true });
       const formLength = deepWrapper.find(Form).length;
       expect(formLength).toEqual(0);
@@ -57,7 +57,7 @@ describe('<CreateTeam />', () => {
   describe('createTeamForDraft', () => {
     const createTeamMock = mockActionFn;
     test('calls createTeam action with page ID param if exists', () => {
-      const deepWrapper = wrapper.dive();
+      const deepWrapper = wrapper.dive().dive();
       const { createTeamForDraft } = deepWrapper.instance();
       deepWrapper.setProps({
         createTeam: createTeamMock,
@@ -71,7 +71,7 @@ describe('<CreateTeam />', () => {
       });
     });
     test('calls createTeam action with ID from selected button if no page ID param', () => {
-      const deepWrapper = wrapper.dive();
+      const deepWrapper = wrapper.dive().dive();
       const { createTeamForDraft } = deepWrapper.instance();
       deepWrapper.setProps({ createTeam: createTeamMock });
       createTeamForDraft('Sharks', 'FooDraft');
@@ -82,7 +82,7 @@ describe('<CreateTeam />', () => {
       });
     });
     test('cancels call and displays error if missing field', () => {
-      const deepWrapper = wrapper.dive();
+      const deepWrapper = wrapper.dive().dive();
       const { createTeamForDraft } = deepWrapper.instance();
       deepWrapper.setProps({ createTeam: createTeamMock });
       createTeamForDraft('Sharks', null);
@@ -93,7 +93,7 @@ describe('<CreateTeam />', () => {
   describe('createRequestToJoinDraft', () => {
     const createRequestMock = mockActionFn;
     test('calls createRequest action if payload is correct', () => {
-      const deepWrapper = wrapper.dive();
+      const deepWrapper = wrapper.dive().dive();
       const { createRequestToJoinDraft } = deepWrapper.instance();
       deepWrapper.setProps({ createRequest: createRequestMock });
       createRequestToJoinDraft('Sharks', 'FooDraft');
@@ -104,7 +104,7 @@ describe('<CreateTeam />', () => {
       });
     });
     test('cancels call and displays error if missing field', () => {
-      const deepWrapper = wrapper.dive();
+      const deepWrapper = wrapper.dive().dive();
       const { createRequestToJoinDraft } = deepWrapper.instance();
       deepWrapper.setProps({ createRequest: createRequestMock });
       createRequestToJoinDraft(null, 'FooDraft');

--- a/client/src/containers/DraftMenu/test/draftMenu.spec.jsx
+++ b/client/src/containers/DraftMenu/test/draftMenu.spec.jsx
@@ -36,7 +36,7 @@ describe('<DraftMenu />', () => {
   test(
     'should render a <Requests /> component as child if ids from currentUser and currentDraft match',
     () => {
-      const requestsLength = wrapper.dive().find(Requests).length;
+      const requestsLength = wrapper.dive().dive().find(Requests).length;
       expect(requestsLength).toEqual(1);
     },
   );
@@ -46,7 +46,7 @@ describe('<DraftMenu />', () => {
       const clonedStore = { ...store };
       clonedStore.draft.currentDraft.ownerUserId = 'ghi789';
       const modifiedWrapper = shallow(<DraftMenu {...props} store={mockStore(clonedStore)} />);
-      const requestsLength = modifiedWrapper.dive().find(Requests).length;
+      const requestsLength = modifiedWrapper.dive().dive().find(Requests).length;
       expect(requestsLength).toEqual(0);
     },
   );

--- a/client/src/containers/Drafts/test/drafts.spec.jsx
+++ b/client/src/containers/Drafts/test/drafts.spec.jsx
@@ -11,7 +11,16 @@ const mockStore = configureStore([thunk]);
 
 const store = {
   draft: {
-    drafts: [{ foo: 'bar' }],
+    drafts: [
+      {
+        uuid: 'abc123',
+        name: 'Foo',
+        User: {
+          firstName: 'Al',
+          lastName: 'Ali',
+        },
+      },
+    ],
   },
 };
 
@@ -24,13 +33,13 @@ describe('<Drafts />', () => {
     expect(received).toEqual(expected);
   });
   test('Renders table as child if drafts exist', () => {
-    const deepWrapper = getWrapper(store).dive();
+    const deepWrapper = getWrapper(store).dive().dive();
     const tableLength = deepWrapper.find(Table).length;
     expect(tableLength).toEqual(1);
   });
   test('Does not render table as child if no drafts exist', () => {
     const modifiedStore = { draft: { drafts: null } };
-    const deepWrapper = getWrapper(modifiedStore).dive();
+    const deepWrapper = getWrapper(modifiedStore).dive().dive();
     const tableLength = deepWrapper.find(Table).length;
     expect(tableLength).toEqual(0);
   });

--- a/client/src/containers/LoggedInView/test/LoggedInView.spec.jsx
+++ b/client/src/containers/LoggedInView/test/LoggedInView.spec.jsx
@@ -8,7 +8,7 @@ describe('<LoggedInView />', () => {
   test('Renders a styled div component', () => {
     const wrapper = shallow(<LoggedInView />);
     const received = wrapper.text();
-    const expected = '<styled.div />';
+    const expected = '<Switch />';
     expect(received).toEqual(expected);
   });
 });

--- a/client/src/containers/Login/test/login.spec.jsx
+++ b/client/src/containers/Login/test/login.spec.jsx
@@ -22,7 +22,7 @@ describe('<LogIn />', () => {
     expect(received).toEqual(expected);
   });
   test('should render a <Form /> component as child', () => {
-    const formLength = wrapper.dive().find(Form).length;
+    const formLength = wrapper.dive().dive().find(Form).length;
     expect(formLength).toEqual(1);
   });
 });

--- a/client/src/containers/Players/test/players.spec.jsx
+++ b/client/src/containers/Players/test/players.spec.jsx
@@ -24,13 +24,13 @@ describe('<Players />', () => {
     expect(received).toEqual(expected);
   });
   test('Renders table as child if Players exist', () => {
-    const deepWrapper = getWrapper(store).dive();
+    const deepWrapper = getWrapper(store).dive().dive();
     const tableLength = deepWrapper.find(Table).length;
     expect(tableLength).toEqual(1);
   });
   test('Does not render table as child if no Players exist', () => {
     const modifiedStore = { player: { players: null } };
-    const deepWrapper = getWrapper(modifiedStore).dive();
+    const deepWrapper = getWrapper(modifiedStore).dive().dive();
     const tableLength = deepWrapper.find(Table).length;
     expect(tableLength).toEqual(0);
   });

--- a/client/src/containers/Requests/test/requests.spec.jsx
+++ b/client/src/containers/Requests/test/requests.spec.jsx
@@ -36,13 +36,13 @@ describe('<Requests />', () => {
     expect(received).toEqual(expected);
   });
   test('Renders table as child if drafts exist', () => {
-    const deepWrapper = getWrapper(store).dive();
+    const deepWrapper = getWrapper(store).dive().dive();
     const tableLength = deepWrapper.find(Table).length;
     expect(tableLength).toEqual(1);
   });
   test('Does not render table as child if no drafts exist', () => {
     const modifiedStore = { request: { requestsForDraft: null } };
-    const deepWrapper = getWrapper(modifiedStore).dive();
+    const deepWrapper = getWrapper(modifiedStore).dive().dive();
     const tableLength = deepWrapper.find(Table).length;
     expect(tableLength).toEqual(0);
   });

--- a/client/src/containers/TeamMenu/test/teamMenu.spec.jsx
+++ b/client/src/containers/TeamMenu/test/teamMenu.spec.jsx
@@ -13,9 +13,13 @@ const mockStore = configureStore([thunk]);
 
 const store = {
   team: {
-    users: [],
-    teams: [{ uuid: 'abc123', name: 'Foo' }],
-    drafts: [],
+    currentTeam: {
+      uuid: 'abc123',
+      name: 'Foo',
+      User: {
+        firstName: 'Al Ali',
+      },
+    },
   },
 };
 
@@ -35,11 +39,11 @@ describe('<TeamMenu />', () => {
     expect(received).toEqual(expected);
   });
   test('should render a <Drafts /> component as child', () => {
-    const draftsLength = wrapper.dive().find(Drafts).length;
+    const draftsLength = wrapper.dive().dive().find(Drafts).length;
     expect(draftsLength).toEqual(1);
   });
   test('should render a <Players /> component as child', () => {
-    const playersLength = wrapper.dive().find(Players).length;
+    const playersLength = wrapper.dive().dive().find(Players).length;
     expect(playersLength).toEqual(1);
   });
 });

--- a/client/src/containers/Teams/test/teams.spec.jsx
+++ b/client/src/containers/Teams/test/teams.spec.jsx
@@ -11,10 +11,19 @@ const mockStore = configureStore([thunk]);
 
 const store = {
   team: {
-    teams: [{ foo: 'bar' }],
-  },
-  draft: {
-    drafts: [],
+    teams: [
+      {
+        uuid: 'abc123',
+        name: 'Foo',
+        User: {
+          firstName: 'Al',
+          lastName: 'Ali',
+        },
+        Draft: {
+          name: 'Bar',
+        },
+      },
+    ],
   },
 };
 
@@ -27,13 +36,13 @@ describe('<Teams />', () => {
     expect(received).toEqual(expected);
   });
   test('Renders table as child if teams exist', () => {
-    const deepWrapper = getWrapper(store).dive();
+    const deepWrapper = getWrapper(store).dive().dive();
     const tableLength = deepWrapper.find(Table).length;
     expect(tableLength).toEqual(1);
   });
   test('Does not render table as child if no teams exist', () => {
     const modifiedStore = { ...store, team: { teams: null } };
-    const deepWrapper = getWrapper(modifiedStore).dive();
+    const deepWrapper = getWrapper(modifiedStore).dive().dive();
     const tableLength = deepWrapper.find(Table).length;
     expect(tableLength).toEqual(0);
   });


### PR DESCRIPTION
Upgrades unit tests for changes introduced in `react-redux` update, namely the requirement to `dive()` twice on the wrapper (see https://github.com/reduxjs/react-redux/issues/1161#issuecomment-489172247).